### PR TITLE
fix: change target to es2019 for Array.flat()

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "allowSyntheticDefaultImports": true,
-    "target": "es2017",
+    "target": "es2019",
     "sourceMap": true,
     "outDir": "./dist",
     "baseUrl": "./",


### PR DESCRIPTION
Issue: #34 

array.flat() was introduced in ES2019, however the target used is es2017 which is incorrect.
Docs: https://262.ecma-international.org/10.0/#sec-array.prototype.flat